### PR TITLE
Feature/devopsprojectname

### DIFF
--- a/.devops/pipelines/azure-infra.yaml
+++ b/.devops/pipelines/azure-infra.yaml
@@ -67,6 +67,7 @@ steps:
       $terraformVariable += "azure_tenant_id=`"$(azure_tenant_id)`""
       $terraformVariable += "devops_token=`"$(devops_token)`""
       $terraformVariable += "devops_pool=`"${{ parameters.azureEnvironment }}`""
+      $terraformVariable += "devops_project=$(System.TeamProject)"
 
       switch ("${{ parameters.azureDelivery }}") {
         "None" {$delivery = "none"}

--- a/.devops/pipelines/azure-infra.yaml
+++ b/.devops/pipelines/azure-infra.yaml
@@ -67,7 +67,8 @@ steps:
       $terraformVariable += "azure_tenant_id=`"$(azure_tenant_id)`""
       $terraformVariable += "devops_token=`"$(devops_token)`""
       $terraformVariable += "devops_pool=`"${{ parameters.azureEnvironment }}`""
-      $terraformVariable += "devops_project=$(System.TeamProject)"
+      $terraformVariable += "devops_project=`"$(System.TeamProject)`""
+      $terraformVariable += "devops_url=`"$(System.CollectionUri)`""
 
       switch ("${{ parameters.azureDelivery }}") {
         "None" {$delivery = "none"}

--- a/terraform/azure/containers.tf
+++ b/terraform/azure/containers.tf
@@ -20,7 +20,7 @@ resource "azurerm_container_group" "docker" {
     memory = "2"
 
     environment_variables = {
-      AZP_URL        = "https://dev.azure.com/${var.devops_orgname}"
+      AZP_URL        = "${var.devops_url}"
       AZP_TOKEN      = "${var.devops_token}"
       AZP_AGENT_NAME = "${local.environment_abbreviations[terraform.workspace]}-${random_integer.agent.result}"
       AZP_POOL       = azuredevops_agent_pool.pool.name

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 provider "azuredevops" {
-  org_service_url       = "https://dev.azure.com/${var.devops_orgname}"
+  org_service_url       = var.devops_url
   personal_access_token = var.devops_token
 }
 

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -71,10 +71,9 @@ variable "azure_tenant_id" {
   sensitive = true
 }
 
-variable "devops_orgname" {
+variable "devops_url" {
   type        = string
-  description = "Azure DevOps oranization name."
-  default     = "go-euc"
+  description = "Azure DevOps url, based on buildin system strings"
 }
 
 variable "devops_token" {


### PR DESCRIPTION
Changed the Azure DevOps URI and Azure DevOps Project name using Azure DevOps build-in vars. So it automatically provisions the Azure DevOps agent in the Azure DevOps project where the pipeline is run from.

Tested this in my own DevOps project and it works. See commits about the changes