### PR TITLE
Hide Security Logs

### DIFF
--- a/ansible/roles/citrix-cloud-connector/tasks/main.yml
+++ b/ansible/roles/citrix-cloud-connector/tasks/main.yml
@@ -34,6 +34,7 @@
     content_type: application/x-www-form-urlencoded
     body: "grant_type=client_credentials&client_id={{ citrix_client_id }}&client_secret={{ citrix_client_secret }}"
     return_content: yes
+  no_log: true
   register: citrix_token
   
 - name: Get Citrix resource locations
@@ -43,6 +44,7 @@
     content_type: application/json
     headers: "{'Authorization': 'CWSAuth bearer={{citrix_token.json.access_token}}'}"
     return_content: yes
+  no_log: true
   register: citrix_resource
 
 - name: Collect the Citrix resource locations from output
@@ -60,6 +62,7 @@
     content_type: application/json
     body: "{'name': '{{ prefix | lower }}-{{ environment_short }}-{{ deploymentname | lower }}-azure', 'internalOnly': false, 'timeZone': 'GMT Standard Time', 'readOnly': false}"
     return_content: yes
+  no_log: true
   register: citrix_new_resource
   when: citrix_resource_id != None
   


### PR DESCRIPTION
Hello,

you for sharing a very interesting playbook.  :)-
However, when I tried to install Cloud Connector via the playbook, I noticed that the secrets and tokens are listed in the event log of the target Windows host. 

To prevent this from happening, 
`"no_log:` true" 
should be included in the playbook. 

There is an interesting discussion on this topic at https://serverfault.com/questions/681832/how-can-i-stop-ansible-from-writing-passwords-to-the-logfile
Thanks and regards 
Dim
